### PR TITLE
fix: use generic completion-read instead of enforcing ido

### DIFF
--- a/js-import.el
+++ b/js-import.el
@@ -59,7 +59,7 @@
   (let* ((filtered-project-files
           (-filter 'js-import-is-js-file (projectile-current-project-files)))
          (all (append (js-import-get-project-dependencies (js-import-get-package-json) section) filtered-project-files))
-         (selected-file (ido-completing-read "Select a file to import: " all))
+         (selected-file (completing-read "Select a file to import: " all))
          (selected-file-name (f-filename (f-no-ext selected-file)))
          (selected-file-relative-path
           (f-relative


### PR DESCRIPTION
As suggested by @vermiculus on the [Reddit thread](https://www.reddit.com/r/emacs/comments/57r4l9/automatically_import_javascript_files/d8u9gbt/), use `completion-read` over the ido-specific version to let non-ido users enjoy the package as well.