### PR TITLE
Enhance import function

### DIFF
--- a/js-import.el
+++ b/js-import.el
@@ -71,7 +71,8 @@
             (f-relative
              (concat (projectile-project-root) (f-no-ext selected-file))
              (file-name-directory (buffer-file-name))))
-           (proposed-symbol (or (word-at-point) selected-file-name))
+           (sap (symbol-at-point))
+           (proposed-symbol (or (and sap (symbol-name sap)) selected-file-name))
            (read-symbols
             (read-string (format "Symbols (default: %s): " proposed-symbol) nil nil proposed-symbol))
            (symbols (if (string-match-p "^[^*]* " read-symbols)

--- a/js-import.el
+++ b/js-import.el
@@ -87,7 +87,7 @@
                symbols
                " from "
                js-import-quote
-               (if (js-import-is-js-file selected-file) (concat selected-file-relative-path) selected-file-name)
+               (if (js-import-is-js-file selected-file) (replace-regexp-in-string "^\\([^\\.]\\)" "./\\1" selected-file-relative-path) selected-file-name)
                js-import-quote
                ";")))))
 

--- a/js-import.el
+++ b/js-import.el
@@ -71,11 +71,11 @@
             (f-relative
              (concat (projectile-project-root) (f-no-ext selected-file))
              (file-name-directory (buffer-file-name))))
-           (w (or (word-at-point) selected-file-name))
+           (proposed-symbol (or (word-at-point) selected-file-name))
            (read-symbols
-            (read-string (format "Symbols (default: %s): " w) nil nil w))
+            (read-string (format "Symbols (default: %s): " proposed-symbol) nil nil proposed-symbol))
            (symbols (if (string-match-p "^[^*]* " read-symbols)
-                        (concat "{ " (replace-regexp-in-string " " ", " read-symbols) " }")
+                        (concat "{ " read-symbols " }")
                       read-symbols)))
 
       (if (re-search-backward "^import " nil t)


### PR DESCRIPTION
- Save excursion
- Remove IDO dependency (completing-read is better and more compatible)
- Support defining the imported symbol
- Imported symbol defaults to word-at-point (Importing unimported symbol under point) or the imported file name
- Support importing all exported symbol in the form 'import * as Sym from "file.js"; ' using input '* as Sym'
- Support importing many symbols in the form 'import { A, B, C } from "file.js"; ' using input 'A B C'
- Support single or double quote types which can be customized